### PR TITLE
api: don't request v3 dogwood variant

### DIFF
--- a/lib/heroku/api/organizations_apps.rb
+++ b/lib/heroku/api/organizations_apps.rb
@@ -1,5 +1,3 @@
-require_relative 'v3_dogwood'
-
 module Heroku
   class API
     def post_organization_app(body)
@@ -7,7 +5,6 @@ module Heroku
         :method => :post,
         :body => MultiJson.dump(body),
         :expects => [201],
-        :headers  => ACCEPT_V3_DOGWOOD,
         :path => "/organizations/apps"
       )
     end
@@ -16,7 +13,6 @@ module Heroku
       request(
         :method => :get,
         :expects => [200],
-        :headers  => ACCEPT_V3_DOGWOOD,
         :path => "/organizations/apps/#{app_identity}"
       )
     end

--- a/lib/heroku/api/organizations_apps.rb
+++ b/lib/heroku/api/organizations_apps.rb
@@ -1,3 +1,5 @@
+require_relative 'v3'
+
 module Heroku
   class API
     def post_organization_app(body)
@@ -5,6 +7,7 @@ module Heroku
         :method => :post,
         :body => MultiJson.dump(body),
         :expects => [201],
+        :headers => ACCEPT_V3,
         :path => "/organizations/apps"
       )
     end
@@ -13,6 +16,7 @@ module Heroku
       request(
         :method => :get,
         :expects => [200],
+        :headers => ACCEPT_V3,
         :path => "/organizations/apps/#{app_identity}"
       )
     end

--- a/lib/heroku/api/spaces.rb
+++ b/lib/heroku/api/spaces.rb
@@ -1,12 +1,9 @@
-require_relative 'v3_dogwood'
-
 module Heroku
   class API
     def get_spaces
       request(
         :method => :get,
         :expects => [200, 206],
-        :headers  => ACCEPT_V3_DOGWOOD,
         :path => "/spaces"
       )
     end
@@ -16,7 +13,6 @@ module Heroku
         :method => :post,
         :body => MultiJson.dump(body),
         :expects => [201],
-        :headers  => ACCEPT_V3_DOGWOOD,
         :path => "/spaces"
       )
     end
@@ -25,7 +21,6 @@ module Heroku
       request(
         :method => :get,
         :expects => [200],
-        :headers  => ACCEPT_V3_DOGWOOD,
         :path => "/spaces/#{space_identity}"
       )
       end
@@ -34,7 +29,6 @@ module Heroku
       request(
         :method => :get,
         :expects => [200],
-        :headers  => ACCEPT_V3_DOGWOOD,
         :path => "/spaces/#{space_identity}/nat"
       )
     end
@@ -44,7 +38,6 @@ module Heroku
         :method => :patch,
         :body => MultiJson.dump(body),
         :expects => [200],
-        :headers  => ACCEPT_V3_DOGWOOD,
         :path => "/spaces/#{space_identity}"
       )
     end
@@ -53,7 +46,6 @@ module Heroku
       request(
         :method => :delete,
         :expects => [200],
-        :headers  => ACCEPT_V3_DOGWOOD,
         :path => "/spaces/#{space_identity}"
       )
     end

--- a/lib/heroku/api/spaces.rb
+++ b/lib/heroku/api/spaces.rb
@@ -1,9 +1,12 @@
+require_relative 'v3'
+
 module Heroku
   class API
     def get_spaces
       request(
         :method => :get,
         :expects => [200, 206],
+        :headers => ACCEPT_V3,
         :path => "/spaces"
       )
     end
@@ -13,6 +16,7 @@ module Heroku
         :method => :post,
         :body => MultiJson.dump(body),
         :expects => [201],
+        :headers => ACCEPT_V3,
         :path => "/spaces"
       )
     end
@@ -21,6 +25,7 @@ module Heroku
       request(
         :method => :get,
         :expects => [200],
+        :headers => ACCEPT_V3,
         :path => "/spaces/#{space_identity}"
       )
       end
@@ -29,6 +34,7 @@ module Heroku
       request(
         :method => :get,
         :expects => [200],
+        :headers => ACCEPT_V3,
         :path => "/spaces/#{space_identity}/nat"
       )
     end
@@ -38,6 +44,7 @@ module Heroku
         :method => :patch,
         :body => MultiJson.dump(body),
         :expects => [200],
+        :headers => ACCEPT_V3,
         :path => "/spaces/#{space_identity}"
       )
     end
@@ -46,6 +53,7 @@ module Heroku
       request(
         :method => :delete,
         :expects => [200],
+        :headers => ACCEPT_V3,
         :path => "/spaces/#{space_identity}"
       )
     end

--- a/lib/heroku/api/v3.rb
+++ b/lib/heroku/api/v3.rb
@@ -1,0 +1,5 @@
+module Heroku
+  class API
+    ACCEPT_V3 = {'Accept' => 'application/vnd.heroku+json; version=3'}
+  end
+end

--- a/lib/heroku/api/v3_dogwood.rb
+++ b/lib/heroku/api/v3_dogwood.rb
@@ -1,5 +1,0 @@
-module Heroku
-  class API
-    ACCEPT_V3_DOGWOOD = { 'Accept' => 'application/vnd.heroku+json; version=3.dogwood'}
-  end
-end


### PR DESCRIPTION
The platform api variant for dogwood is merging into production v3 so there's no need to request the variant any longer.