### PR TITLE
whitelist: Add support for modifying the whitelist for a Space.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,2 +1,3 @@
 require File.expand_path('../lib/heroku/command/spaces', __FILE__)
 require File.expand_path('../lib/heroku/command/dapps', __FILE__)
+require File.expand_path('../lib/heroku/command/whitelist', __FILE__)

--- a/lib/heroku/api/spaces.rb
+++ b/lib/heroku/api/spaces.rb
@@ -28,7 +28,7 @@ module Heroku
         :headers => ACCEPT_V3,
         :path => "/spaces/#{space_identity}"
       )
-      end
+    end
 
     def get_space_nat(space_identity)
       request(

--- a/lib/heroku/api/v3.rb
+++ b/lib/heroku/api/v3.rb
@@ -1,5 +1,6 @@
 module Heroku
   class API
     ACCEPT_V3 = {'Accept' => 'application/vnd.heroku+json; version=3'}
+    ACCEPT_V3_DOGWOOD = {'Accept' => 'application/vnd.heroku+json; version=3.dogwood'}
   end
 end

--- a/lib/heroku/api/whitelist.rb
+++ b/lib/heroku/api/whitelist.rb
@@ -1,0 +1,24 @@
+require_relative 'v3'
+
+module Heroku
+  class API
+    def get_whitelist(space_identity)
+      request(
+        :method => :get,
+        :expects => [200],
+        :headers => ACCEPT_V3_DOGWOOD,
+        :path => "/spaces/#{space_identity}/inbound-ruleset"
+      )
+    end
+
+    def put_whitelist(space_identity, whitelist)
+      request(
+        :method => :put,
+        :body => MultiJson.dump(whitelist),
+        :expects => [200],
+        :headers => ACCEPT_V3_DOGWOOD,
+        :path => "/spaces/#{space_identity}/inbound-ruleset"
+      )
+    end
+  end
+end

--- a/lib/heroku/command/whitelist.rb
+++ b/lib/heroku/command/whitelist.rb
@@ -32,7 +32,7 @@ class Heroku::Command::Whitelist < Heroku::Command::Base
     new_whitelist = api.put_whitelist(options[:space], whitelist).body
 
     style new_whitelist
-    display('It may take a few moments for the changes to take effect.')
+    display_delay
   end
 
   # whitelist:add --space SPACE --source SOURCE

--- a/lib/heroku/command/whitelist.rb
+++ b/lib/heroku/command/whitelist.rb
@@ -1,0 +1,137 @@
+require 'heroku/api/whitelist'
+class Heroku::Command::Whitelist < Heroku::Command::Base
+
+  # whitelist
+  #
+  # displays inbound connection whitelist for space.
+  #
+  # --space SPACE   # name of space
+  #
+  def index
+    require_argument! :space
+    validate_arguments!
+
+    whitelist = api.get_whitelist(options[:space]).body
+    style whitelist
+  end
+
+  # whitelist:default [allow|deny]
+  #
+  # sets the default action for a spaces inbound ruleset/whitelist
+  #
+  # --space SPACE # name of space
+  def default
+    default = extract_default_arg!
+    require_argument! :space
+    validate_arguments!
+
+    return unless confirm
+    whitelist = api.get_whitelist(options[:space]).body
+    whitelist[:default_action] = default
+
+    new_whitelist = api.put_whitelist(options[:space], whitelist).body
+
+    style new_whitelist
+    display('It may take a few moments for the changes to take effect.')
+  end
+
+  # whitelist:add --space SPACE --source SOURCE
+  #
+  # Adds rules to the inbound ruleset/whitelist.
+  #
+  # --space SPACE # name of space
+  # --source SOURCE # source of inbound requests in CIDR notation.
+  def add
+    require_argument! :space
+    require_argument! :source
+    validate_arguments!
+
+    whitelist = api.get_whitelist(options[:space]).body
+    rules = whitelist.fetch(:rules, [])
+    exists = rules.find {|rs| rs[:source] == options[:source]}
+    if exists
+      display("A rule already exists for #{options[:source]}")
+      exit(1)
+    end
+
+    new_rule = {action: 'allow', source: options[:source]}
+    rules << new_rule
+    whitelist[:rules] = rules
+
+    new_whitelist = api.put_whitelist(options[:space], whitelist).body
+    style new_whitelist
+
+    display_delay
+  end
+
+  # whitelist:remove --space SPACE --source SOURCE
+  #
+  # Removes rules from the inbound ruleset/whitelist.
+  #
+  # --space SPACE # name of space
+  # --source SOURCE # source of inbound requests in CIDR notation.
+  def remove
+    require_argument! :space
+    require_argument! :source
+    validate_arguments!
+
+    whitelist = api.get_whitelist(options[:space]).body
+    rules = whitelist.fetch(:rules, [])
+    exists = rules.delete_if {|rs| rs[:source] == options[:source]}
+    if exists
+      whitelist[:rules] = rules
+      new_whitelist = api.put_whitelist(options[:space], whitelist).body
+      style new_whitelist
+      display_delay
+    else
+      display("A rule already match #{options[:source]} was not found")
+      exit(1)
+    end
+  end
+
+  private
+
+  def extract_default_arg!
+    default = shift_argument
+    if default.nil?
+      Heroku::Command.run(current_command, ['--help'])
+      exit(1)
+    end
+    default
+  end
+
+  def require_argument!(arg)
+    return if options.key?(arg)
+    output_with_bang("An argument for \"--#{arg.to_s }\" must be provided.")
+    Heroku::Command.run(current_command, ['--help'])
+    exit(1)
+  end
+
+  def for_display(whitelist)
+    {
+      'Version'    => whitelist['version'],
+      'Rules'      => style_rules(whitelist['rules']),
+      'Created By' => whitelist['created_by'],
+      'Created At' => whitelist['created_at'],
+    }
+  end
+
+  def style(whitelist)
+    styled_header("DEFAULT ACTION: #{whitelist['default_action']}")
+    keys = []
+    keys << 'Version'
+    keys << 'Created By'
+    keys << 'Created At'
+    styled_hash(for_display(whitelist), keys)
+  end
+
+  def style_rules(rules)
+    return unless rules.size > 0
+    cols = ['Source', 'Action']
+    display_table(rules.map{|r| {'Source'=>r["source"], 'Action' => r["action"]}}, cols, cols)
+  end
+
+  def display_delay
+    display("\nIt may take a few moments for the changes to take effect.")
+  end
+end


### PR DESCRIPTION
## Adding support for inbound ruleset modification

This adds three new commands to the plugin:

`heroku whitelist`
`heroku whitelist:add --space SPACE --source CIDR notated source address`
`heroku whitelist:remove --space SPACE --source CIDR notated source address`

#### Examples:

**Display the default state**
```shell
% heroku whitelist --space amerine
=== DEFAULT ACTION: allow
Created By: amerine@heroku.com
Created At: 2015-12-23T20:09:49Z
```

**Changing the default action**
```shell
% heroku whitelist:default deny --space amerine
Are you sure you wish to continue? (y/n) y
=== DEFAULT ACTION: deny
Created By: amerine@heroku.com
Created At: 2015-12-23T20:15:14Z

It may take a few moments for the changes to take effect.
```

**Adding a rule**
```shell
% heroku whitelist:add --space amerine --source 174.25.11.0/24
=== DEFAULT ACTION: deny
Source          Action
--------------  ------
174.25.11.0/24  allow
Created By: amerine@heroku.com
Created At: 2015-12-23T20:16:20Z

It may take a few moments for the changes to take effect.
```

**Removing a rule**
```shell
% heroku whitelist:remove --space amerine --source 174.25.11.0/24
=== DEFAULT ACTION: deny
Created By: amerine@heroku.com
Created At: 2015-12-23T20:16:41Z

It may take a few moments for the changes to take effect.
```
cc/ @jsullivan @sclasen @daneharrigan 