### PR TITLE
trusted-ips: Remove warnings.

### DIFF
--- a/commands/trusted-ips/add.js
+++ b/commands/trusted-ips/add.js
@@ -9,7 +9,6 @@ function* run (context, heroku) {
   let ruleset = yield lib.getRules(space);
   ruleset.rules = ruleset.rules || [];
   if (ruleset.rules.find(rs => rs.source === context.args.source)) throw new Error(`A rule already exists for ${context.args.source}.`);
-  if (ruleset.rules.length === 0) yield cli.confirmApp(space, context.flags.confirm, `Traffic from ${cli.color.red(context.args.source)} will be allowed to make web requests to web dynos, all other inbound traffic denied.`);
   ruleset.rules.push({action: 'allow', source: context.args.source});
   ruleset = yield lib.putRules(space, ruleset);
   cli.log(`Added ${cli.color.cyan.bold(context.args.source)} to trusted IP ranges on ${cli.color.cyan.bold(space)}`);

--- a/commands/trusted-ips/remove.js
+++ b/commands/trusted-ips/remove.js
@@ -12,12 +12,6 @@ function* run (context, heroku) {
   let originalLength = rules.rules.length;
   rules.rules = rules.rules.filter(r => r.source !== context.args.source);
   if (rules.rules.length === originalLength) throw new Error(`No IP range matching ${context.args.source} was found.`);
-  if (rules.rules.length === 0) {
-    yield cli.confirmApp(
-      space,
-      context.flags.confirm,
-      `You are removing the last trusted IP range. Web traffic from any source will not able to access apps in this space.`);
-  }
   rules = yield lib.putRules(space, rules);
   cli.log(`Removed ${cli.color.cyan.bold(context.args.source)} from trusted IP ranges on ${cli.color.cyan.bold(space)}`);
   cli.warn('It may take a few moments for the changes to take effect.');


### PR DESCRIPTION
Superflous and unnecessary. 