### PR TITLE
Space Log Drains CLI Commands

### DIFF
--- a/commands/create.js
+++ b/commands/create.js
@@ -14,6 +14,7 @@ function* run(context, heroku) {
       organization: context.flags.org,
       channel_name: context.flags.channel,
       region: context.flags.region,
+      log_drain_url: context.flags['log-drain-url'],
     }
   });
   space = yield cli.action(`Creating space ${cli.color.green(space)} in organization ${cli.color.cyan(context.flags.org)}`, request);
@@ -50,6 +51,7 @@ Example:
     {name: 'org', char: 'o', required: true, hasValue: true, description: 'organization name'},
     {name: 'channel', hasValue: true, hidden: true},
     {name: 'region', hasValue: true, description: 'region name'},
+    {name: 'log-drain-url', hasValue: true, hidden: true, description: 'direct log drain url'},
   ],
   run: cli.command(co.wrap(run))
 };

--- a/commands/drains/get.js
+++ b/commands/drains/get.js
@@ -1,0 +1,29 @@
+'use strict';
+
+let cli = require('heroku-cli-util');
+let co  = require('co');
+
+function* run (context, heroku) {
+  let lib = require('../../lib/log-drains')(heroku);
+  let drain = yield lib.getLogDrain(context.flags.space);
+  if (context.flags.json) {
+    cli.log(JSON.stringify(drain, null, 2));
+  } else {
+    let output = `${cli.color.cyan(drain.url)} (${cli.color.green(drain.token)})`;
+    cli.log(output);
+  }
+}
+
+module.exports = {
+  topic: 'drains',
+  command: 'get',
+  hidden: true,
+  description: 'display the log drain for a space',
+  needsApp: false,
+  needsAuth: true,
+  flags: [
+    {name: 'space', char: 's', hasValue: true, description: 'space for which to get log drain', required: true},
+    {name: 'json', description: 'output in json format'},
+  ],
+  run: cli.command(co.wrap(run))
+};

--- a/commands/drains/set.js
+++ b/commands/drains/set.js
@@ -1,0 +1,28 @@
+'use strict';
+
+let cli = require('heroku-cli-util');
+let co  = require('co');
+
+function* run (context, heroku) {
+  let lib = require('../../lib/log-drains')(heroku);
+  let space = context.flags.space;
+  let drain = yield lib.putLogDrain(space, context.args.url);
+  cli.log(`Successfully set drain ${cli.color.cyan(drain.url)} for ${cli.color.cyan.bold(space)}.`);
+  cli.warn('It may take a few moments for the changes to take effect.');
+}
+
+module.exports = {
+  topic: 'drains',
+  command: 'set',
+  hidden: true,
+  description: 'replaces the log drain for a space',
+  needsApp: false,
+  needsAuth: true,
+  args: [
+    {name: 'url'},
+  ],
+  flags: [
+    {name: 'space', char: 's', hasValue: true, description: 'space for which to set log drain', required: true},
+  ],
+  run: cli.command(co.wrap(run))
+};

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ exports.commands = [
   require('./commands/destroy'),
   require('./commands/info'),
   require('./commands/rename'),
+  require('./commands/drains/get'),
+  require('./commands/drains/set'),
   require('./commands/trusted-ips'),
   require('./commands/trusted-ips/add'),
   require('./commands/trusted-ips/remove'),

--- a/lib/log-drains.js
+++ b/lib/log-drains.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = function (heroku) {
+  function getLogDrain (space) {
+    return heroku.request({
+      path:    `/spaces/${space}/log-drain`,
+      headers: {Accept: 'application/vnd.heroku+json; version=3.dogwood'},
+    });
+  }
+
+  function putLogDrain (space, url) {
+    return heroku.request({
+      method:  'PUT',
+      path:    `/spaces/${space}/log-drain`,
+      body:    {
+        url: url
+      },
+      headers: {Accept: 'application/vnd.heroku+json; version=3.dogwood'},
+    });
+  }
+
+  return {
+    getLogDrain,
+    putLogDrain,
+  };
+};

--- a/test/commands/drains/get.js
+++ b/test/commands/drains/get.js
@@ -1,0 +1,28 @@
+'use strict';
+
+let nock     = require('nock');
+let cmd      = require('../../../commands/drains/get');
+let expect   = require('chai').expect;
+
+describe('drains:get', function() {
+  beforeEach(() => cli.mockConsole());
+
+  it('shows the log drain', function() {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/log-drain')
+      .reply(200,
+        {
+          addon: null,
+          created_at: '2016-03-23T18:31:50Z',
+          id: '047f80cc-0470-4564-b0cb-e9ad7605314a',
+          token: 'd.a55ecbe1-5513-4d19-91e4-58a08b419d19',
+          updated_at: '2016-03-23T18:31:50Z',
+          url: 'https://example.com'
+        }
+      );
+    return cmd.run({flags: {space: 'my-space'}})
+        .then(() => expect(cli.stdout).to.equal(
+        `https://example.com (d.a55ecbe1-5513-4d19-91e4-58a08b419d19)\n`
+      )).then(() => api.done());
+  });
+});

--- a/test/commands/drains/set.js
+++ b/test/commands/drains/set.js
@@ -1,0 +1,30 @@
+'use strict';
+
+let nock     = require('nock');
+let cmd      = require('../../../commands/drains/set');
+let expect   = require('chai').expect;
+
+describe('drains:set', function() {
+  beforeEach(() => cli.mockConsole());
+
+  it('shows the log drain', function() {
+    let api = nock('https://api.heroku.com:443')
+      .put('/spaces/my-space/log-drain', {
+        url: 'https://example.com'
+      })
+      .reply(200,
+        {
+          addon: null,
+          created_at: '2016-03-23T18:31:50Z',
+          id: '047f80cc-0470-4564-b0cb-e9ad7605314a',
+          token: 'd.a55ecbe1-5513-4d19-91e4-58a08b419d19',
+          updated_at: '2016-03-23T18:31:50Z',
+          url: 'https://example.com'
+        }
+      );
+    return cmd.run({args: {url: 'https://example.com'}, flags: {space: 'my-space'}})
+        .then(() => expect(cli.stdout).to.equal(
+        `Successfully set drain https://example.com for my-space.\n`
+      )).then(() => api.done());
+  });
+});


### PR DESCRIPTION
This modifies/adds the following CLI commands:

 - `heroku spaces:create --log-drain-url`: adds the new `--log-drain-url` flag to activate direct logging. Also requires a user pass.
 - `heroku drains:get --space SPACE`: gets the log drain for a space. spoke with product, and the decision was to keep this under the `drains` namespace like this for consistency. we might change it in the future and/or stick it in the space's info, but this is what we're going with for now.
 - `heroku drains:set URL --space SPACE`: replaces the log drain for a space. same caveat about the namespace. feedback of course is welcome, but wanted to get something out there to be able to use the feature.

This should not be published until API changes (https://github.com/heroku/api/pull/5750) are deployed, although all the changes are hidden, so not a hard requirement.

cc: @amerine @daneharrigan 