### PR TITLE
spaces: add spend alert to space creation output

### DIFF
--- a/commands/create.js
+++ b/commands/create.js
@@ -17,7 +17,10 @@ function * run (context, heroku) {
       log_drain_url: context.flags['log-drain-url']
     }
   })
-  space = yield cli.action(`Creating space ${cli.color.green(space)} in organization ${cli.color.cyan(context.org)}`, request)
+  space = yield cli.action(`
+${cli.color.bold('Spend Alert.')} Each Heroku Private Space costs $1000 in Add-on Credits/month (pro-rated to the second).
+
+Creating space ${cli.color.green(space)} in organization ${cli.color.cyan(context.org)}`, request)
   cli.styledHeader(space.name)
   cli.styledObject({
     ID: space.id,


### PR DESCRIPTION
This just adds a minor wording addition to stdout when a user creates a Space. The spend alert wording is the same as what shows up in the space create view in the dashboard.