### PR TITLE
Fix double printed spend alert

### DIFF
--- a/commands/create.js
+++ b/commands/create.js
@@ -17,10 +17,8 @@ function * run (context, heroku) {
       log_drain_url: context.flags['log-drain-url']
     }
   })
-  space = yield cli.action(`
-${cli.color.bold('Spend Alert.')} Each Heroku Private Space costs $1000 in Add-on Credits/month (pro-rated to the second).
-
-Creating space ${cli.color.green(space)} in organization ${cli.color.cyan(context.org)}`, request)
+  cli.warn(`${cli.color.bold('Spend Alert.')} Each Heroku Private Space costs $1000 in Add-on Credits/month (pro-rated to the second).`)
+  space = yield cli.action(`Creating space ${cli.color.green(space)} in organization ${cli.color.cyan(context.org)}`, request)
   cli.styledHeader(space.name)
   cli.styledObject({
     ID: space.id,


### PR DESCRIPTION
An outdated dependency was preventing this issue from appearing locally for me. Separating the alert into a warning message using one of our utility helpers is more in line with how we should display the alert anyway. So this fixes the original issue and displays the warning properly now.