### PR TITLE
Outbound Rules

### DIFF
--- a/commands/outbound-rules/add.js
+++ b/commands/outbound-rules/add.js
@@ -6,11 +6,16 @@ let co = require('co')
 function * run (context, heroku) {
   let lib = require('../../lib/outbound-rules')(heroku)
   let space = context.flags.space
-  let ruleset = yield lib.getRules(space)
+  let ruleset = yield lib.getOutboundRules(space)
   ruleset.rules = ruleset.rules || []
-  ruleset.rules.push({action: 'allow', source: context.args.source})
-  ruleset = yield lib.putRules(space, ruleset)
-  cli.log(`Added ${cli.color.cyan.bold(context.args.source)} to trusted IP ranges on ${cli.color.cyan.bold(space)}`)
+  let ports = yield lib.parsePorts(context.flags.port)
+  ruleset.rules.push({
+    target: context.flags.dest,
+    from_port: ports[0],
+    to_port: ports[1] || ports[0],
+    protocol: context.flags.protocol})
+  ruleset = yield lib.putOutboundRules(space, ruleset)
+  cli.log(`Added rule to the Outbound Rules of ${cli.color.cyan.bold(space)}`)
   cli.warn('It may take a few moments for the changes to take effect.')
 }
 

--- a/commands/outbound-rules/add.js
+++ b/commands/outbound-rules/add.js
@@ -16,7 +16,7 @@ function * run (context, heroku) {
     protocol: context.flags.protocol})
   ruleset = yield lib.putOutboundRules(space, ruleset)
   cli.log(`Added rule to the Outbound Rules of ${cli.color.cyan.bold(space)}`)
-  cli.warn('It may take a few moments for the changes to take effect.')
+  cli.warn('Modifying the Outbound Rules may break Add-ons for Apps in this Private Space')
 }
 
 module.exports = {

--- a/commands/outbound-rules/add.js
+++ b/commands/outbound-rules/add.js
@@ -1,0 +1,39 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+let co = require('co')
+
+function * run (context, heroku) {
+  let lib = require('../../lib/outbound-rules')(heroku)
+  let space = context.flags.space
+  let ruleset = yield lib.getRules(space)
+  ruleset.rules = ruleset.rules || []
+  ruleset.rules.push({action: 'allow', source: context.args.source})
+  ruleset = yield lib.putRules(space, ruleset)
+  cli.log(`Added ${cli.color.cyan.bold(context.args.source)} to trusted IP ranges on ${cli.color.cyan.bold(space)}`)
+  cli.warn('It may take a few moments for the changes to take effect.')
+}
+
+module.exports = {
+  topic: 'outbound-rules',
+  command: 'add',
+  description: 'Add outbound rules to a Private Space',
+  help: `
+Uses CIDR notation.
+
+Example:
+  $ heroku outbound-rules:add --space my-space --dest 192.168.2.0/24 --protocol tcp --port 80
+  Added 192.168.0.1/24 to the outbound rules on my-space
+  `,
+  needsApp: false,
+  needsAuth: true,
+  args: [],
+  flags: [
+    {name: 'space', char: 's', hasValue: true, description: 'space to add rule to'},
+    {name: 'confirm', hasValue: true, description: 'set to space name to bypass confirm prompt'},
+    {name: 'dest', hasValue: true, description: 'target CIDR block Dynos are allowed to communicate with'},
+    {name: 'protocol', hasValue: true, description: 'the protocol Dynos are allowed to use when communicating with hosts in destination CIDR block'},
+    {name: 'port', hasValue: true, description: 'the port Dynos are allowed to use when communicating with hosts in destination CIDR block'}
+  ],
+  run: cli.command(co.wrap(run))
+}

--- a/commands/outbound-rules/add.js
+++ b/commands/outbound-rules/add.js
@@ -24,11 +24,19 @@ module.exports = {
   command: 'add',
   description: 'Add outbound rules to a Private Space',
   help: `
-Uses CIDR notation.
+The destination flag uses CIDR notation.
 
 Example:
   $ heroku outbound-rules:add --space my-space --dest 192.168.2.0/24 --protocol tcp --port 80
   Added 192.168.0.1/24 to the outbound rules on my-space
+
+Example with port range:
+  $ heroku outbound-rules:add --space my-space --dest 192.168.2.0/24 --protocol tcp --port 80-100
+  Added 192.168.0.1/24 to the outbound rules on my-space
+
+Example opening up everything
+  $ heroku outbound-rules:add --space my-space --dest 0.0.0.0/0 --protocol any --port any
+  Added 0.0.0.0/0 to the outbound rules on my-space
   `,
   needsApp: false,
   needsAuth: true,
@@ -36,9 +44,9 @@ Example:
   flags: [
     {name: 'space', char: 's', hasValue: true, description: 'space to add rule to'},
     {name: 'confirm', hasValue: true, description: 'set to space name to bypass confirm prompt'},
-    {name: 'dest', hasValue: true, description: 'target CIDR block Dynos are allowed to communicate with'},
-    {name: 'protocol', hasValue: true, description: 'the protocol Dynos are allowed to use when communicating with hosts in destination CIDR block'},
-    {name: 'port', hasValue: true, description: 'the port Dynos are allowed to use when communicating with hosts in destination CIDR block'}
+    {name: 'dest', hasValue: true, description: 'target CIDR block dynos are allowed to communicate with'},
+    {name: 'protocol', hasValue: true, description: 'the protocol dynos are allowed to use when communicating with hosts in destination CIDR block. Valid protocols are "tcp", "udp", "icmp", "0-255" and "any".'},
+    {name: 'port', hasValue: true, description: 'the port dynos are allowed to use when communicating with hosts in destination CIDR block. Accepts a range in `<lowest port>-<highest port>` format. The maximum port allowed for ICMP traffic is 255.'}
   ],
   run: cli.command(co.wrap(run))
 }

--- a/commands/outbound-rules/add.js
+++ b/commands/outbound-rules/add.js
@@ -9,7 +9,7 @@ function * run (context, heroku) {
   if (!space) throw new Error('Space name required.')
   let ruleset = yield lib.getOutboundRules(space)
   ruleset.rules = ruleset.rules || []
-  let ports = yield lib.parsePorts(context.flags.port)
+  let ports = yield lib.parsePorts(context.flags.protocol, context.flags.port)
   ruleset.rules.push({
     target: context.flags.dest,
     from_port: ports[0],

--- a/commands/outbound-rules/add.js
+++ b/commands/outbound-rules/add.js
@@ -6,6 +6,7 @@ let co = require('co')
 function * run (context, heroku) {
   let lib = require('../../lib/outbound-rules')(heroku)
   let space = context.flags.space
+  if (!space) throw new Error('Space name required.')
   let ruleset = yield lib.getOutboundRules(space)
   ruleset.rules = ruleset.rules || []
   let ports = yield lib.parsePorts(context.flags.port)

--- a/commands/outbound-rules/add.js
+++ b/commands/outbound-rules/add.js
@@ -46,7 +46,7 @@ Example opening up everything
     {name: 'confirm', hasValue: true, description: 'set to space name to bypass confirm prompt'},
     {name: 'dest', hasValue: true, description: 'target CIDR block dynos are allowed to communicate with'},
     {name: 'protocol', hasValue: true, description: 'the protocol dynos are allowed to use when communicating with hosts in destination CIDR block. Valid protocols are "tcp", "udp", "icmp", "0-255" and "any".'},
-    {name: 'port', hasValue: true, description: 'the port dynos are allowed to use when communicating with hosts in destination CIDR block. Accepts a range in `<lowest port>-<highest port>` format. The maximum port allowed for ICMP traffic is 255.'}
+    {name: 'port', hasValue: true, description: 'the port dynos are allowed to use when communicating with hosts in destination CIDR block. Accepts a range in `<lowest port>-<highest port>` format. 0 is the minimum. The maximum port allowed for ICMP traffic is 255, otherwise the maximum is 65535.'}
   ],
   run: cli.command(co.wrap(run))
 }

--- a/commands/outbound-rules/add.js
+++ b/commands/outbound-rules/add.js
@@ -38,6 +38,11 @@ Example with port range:
 Example opening up everything
   $ heroku outbound-rules:add --space my-space --dest 0.0.0.0/0 --protocol any --port any
   Added 0.0.0.0/0 to the outbound rules on my-space
+
+ICMP Rules
+The ICMP protocol has types, not ports, but the underlying systems treat them as the same. For this reason,
+when you want to allow ICMP traffic you will use the --port flag to specify the ICMP types you want to
+allow. ICMP types are numbered, 0-255.
   `,
   needsApp: false,
   needsAuth: true,
@@ -47,7 +52,7 @@ Example opening up everything
     {name: 'confirm', hasValue: true, description: 'set to space name to bypass confirm prompt'},
     {name: 'dest', hasValue: true, description: 'target CIDR block dynos are allowed to communicate with'},
     {name: 'protocol', hasValue: true, description: 'the protocol dynos are allowed to use when communicating with hosts in destination CIDR block. Valid protocols are "tcp", "udp", "icmp", "0-255" and "any".'},
-    {name: 'port', hasValue: true, description: 'the port dynos are allowed to use when communicating with hosts in destination CIDR block. Accepts a range in `<lowest port>-<highest port>` format. 0 is the minimum. The maximum port allowed for ICMP traffic is 255, otherwise the maximum is 65535.'}
+    {name: 'port', hasValue: true, description: 'the port dynos are allowed to use when communicating with hosts in destination CIDR block. Accepts a range in `<lowest port>-<highest port>` format. 0 is the minimum. The maximum port allowed is 65535, except for ICMP with a maximum of 255.'}
   ],
   run: cli.command(co.wrap(run))
 }

--- a/commands/outbound-rules/index.js
+++ b/commands/outbound-rules/index.js
@@ -23,11 +23,11 @@ module.exports = {
 Outbound Rules are only available on Private Spaces.
 
 Newly created spaces will have an "Allow All" rule set by default
-allowing all egress Dyno traffic outside of the space.  You can
-remove this default rule to completely stop your Private Dynos from
+allowing all egress dyno traffic outside of the space.  You can
+remove this default rule to completely stop your private dynos from
 talking to the world.
 
-You can add specific rules that only allow your Dyno to communicate with trusted hosts.
+You can add specific rules that only allow your dyno to communicate with trusted hosts.
   `,
   needsApp: false,
   needsAuth: true,

--- a/commands/outbound-rules/index.js
+++ b/commands/outbound-rules/index.js
@@ -1,0 +1,40 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+let co = require('co')
+
+function displayJSON (rules) {
+  cli.log(JSON.stringify(rules, null, 2))
+}
+
+function * run (context, heroku) {
+  let lib = require('../../lib/outbound-rules')(heroku)
+  let space = context.flags.space || context.args.space
+  if (!space) throw new Error('Space name required.\nUSAGE: heroku outbound-rules --space my-space')
+  let rules = yield lib.getOutboundRules(space)
+  if (context.flags.json) displayJSON(rules)
+  else lib.displayRules(space, rules)
+}
+
+module.exports = {
+  topic: 'outbound-rules',
+  description: 'list Outbound Rules for a space',
+  help: `
+Outbound Rules are only available on Private Spaces.
+
+Newly created spaces will have an "Allow All" rule set by default
+allowing all egress Dyno traffic outside of the space.  You can
+remove this default rule to completely stop your Private Dynos from
+talking to the world.
+
+You can add specific rules that only allow your Dyno to communicate with trusted hosts.
+  `,
+  needsApp: false,
+  needsAuth: true,
+  args: [{name: 'space', optional: true, hidden: true}],
+  flags: [
+    {name: 'space', char: 's', hasValue: true, description: 'space to get outbound rules from'},
+    {name: 'json', description: 'output in json format'}
+  ],
+  run: cli.command(co.wrap(run))
+}

--- a/commands/outbound-rules/remove.js
+++ b/commands/outbound-rules/remove.js
@@ -6,6 +6,7 @@ let co = require('co')
 function * run (context, heroku) {
   let lib = require('../../lib/outbound-rules')(heroku)
   let space = context.flags.space
+  if (!space) throw new Error('Space name required.')
   let rules = yield lib.getOutboundRules(space)
   rules.rules = rules.rules || []
 

--- a/commands/outbound-rules/remove.js
+++ b/commands/outbound-rules/remove.js
@@ -11,7 +11,7 @@ function * run (context, heroku) {
 
   if (rules.rules.length === 0) throw new Error('No Outbound Rules configured. Nothing to do.')
 
-  let deleted = rules.rules.splice(context.args.rulenumber - 1, 1)[0]
+  let deleted = rules.rules.splice(context.args.ruleNumber - 1, 1)[0]
 
   yield cli.confirmApp(space, context.flags.confirm, `Destructive Action
 This will remove:
@@ -35,7 +35,7 @@ Example:
   needsApp: false,
   needsAuth: true,
   args: [
-    {name: 'rulenumber'}
+    {name: 'ruleNumber'}
   ],
   flags: [
     {name: 'space', hasValue: true, optional: false, description: 'space to remove rule from'},

--- a/commands/outbound-rules/remove.js
+++ b/commands/outbound-rules/remove.js
@@ -1,0 +1,37 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+let co = require('co')
+
+function * run (context, heroku) {
+  let lib = require('../../lib/outbound-rules')(heroku)
+  let space = context.flags.space
+  let rules = yield lib.getOutboundRules(space)
+  rules.rules = rules.rules || []
+  if (rules.rules.length === 0) throw new Error('No Outbound Rules configured. Nothing to do.')
+  if (rules.rules.length === originalLength) throw new Error(`No IP range matching ${context.args.source} was found.`)
+  rules = yield lib.putRules(space, rules)
+  cli.log(`Removed ${cli.color.cyan.bold(context.args)} from Outbound Rules on ${cli.color.cyan.bold(space)}`)
+  cli.warn('It may take a few moments for the changes to take effect.')
+}
+
+module.exports = {
+  topic: 'outbound-rules',
+  command: 'remove',
+  description: 'Remove a Rules from the list of Outbound Rules',
+  help: `
+Example:
+  $ heroku outbound-rules:remove --space my-space 4
+  Removed 192.168.2.0/24 from trusted IP ranges on my-space
+  `,
+  needsApp: false,
+  needsAuth: true,
+  args: [
+    {name: 'rulenumber'}
+  ],
+  flags: [
+    {name: 'space', hasValue: true, optional: false, description: 'space to remove rule from'},
+    {name: 'confirm', hasValue: true, description: 'set to space name to bypass confirm prompt'}
+  ],
+  run: cli.command(co.wrap(run))
+}

--- a/commands/outbound-rules/remove.js
+++ b/commands/outbound-rules/remove.js
@@ -11,7 +11,7 @@ function * run (context, heroku) {
 
   if (rules.rules.length === 0) throw new Error('No Outbound Rules configured. Nothing to do.')
 
-  let deleted = rules.rules.splice(context.args.source - 1, 1)[0]
+  let deleted = rules.rules.splice(context.args.rulenumber - 1, 1)[0]
 
   yield cli.confirmApp(space, context.flags.confirm, `Destructive Action
 This will remove:

--- a/index.js
+++ b/index.js
@@ -15,5 +15,8 @@ exports.commands = [
   require('./commands/drains/set'),
   require('./commands/trusted-ips'),
   require('./commands/trusted-ips/add'),
-  require('./commands/trusted-ips/remove')
+  require('./commands/trusted-ips/remove'),
+  require('./commands/outbound-rules'),
+  require('./commands/outbound-rules/add'),
+  require('./commands/outbound-rules/remove')
 ]

--- a/lib/outbound-rules.js
+++ b/lib/outbound-rules.js
@@ -1,0 +1,51 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+
+module.exports = function (heroku) {
+  function getOutboundRules (space) {
+    return heroku.request({
+      path: `/spaces/${space}/outbound-ruleset`,
+      headers: {Accept: 'application/vnd.heroku+json; version=3.dogwood'}
+    })
+  }
+
+  function putOutboundRules (space, ruleset) {
+    return heroku.request({
+      method: 'PUT',
+      path: `/spaces/${space}/outbound-ruleset`,
+      body: ruleset,
+      headers: {Accept: 'application/vnd.heroku+json; version=3.dogwood'}
+    })
+  }
+
+  function displayRules (space, ruleset) {
+    if (ruleset.rules.length > 0) {
+      cli.styledHeader('Outbound Rules')
+      display(ruleset.rules)
+    } else {
+      cli.styledHeader(`${space} has no Outbound Rules. Your Dynos cannot communicate with hosts outside of ${space}.`)
+    }
+  }
+
+  function display (rules) {
+    var f = function(p) {
+      var n = p
+      return p.toString()
+    }
+    cli.table(rules, {
+      columns: [
+        {key: 'target', label: 'Destination'},
+        {key: 'from_port', label: 'From Port', format: from_port => f(from_port)},
+        {key: 'to_port', label: 'To Port'},
+        {key: 'protocol', label: 'Protocol'}
+      ]
+    })
+  }
+
+  return {
+    getOutboundRules,
+    putOutboundRules,
+    displayRules
+  }
+}

--- a/lib/outbound-rules.js
+++ b/lib/outbound-rules.js
@@ -28,13 +28,32 @@ module.exports = function (heroku) {
     }
   }
 
+  function lined (rules) {
+    var count = 0
+    var lined = []
+    for (var i = 0, len = rules.length; i < len; i++) {
+      lined.push({
+        line: i+1,
+        target: rules[i].target,
+        from_port: rules[i].from_port,
+        to_port: rules[i].to_port,
+        target: rules[i].target,
+        protocol: rules[i].protocol
+      })
+    }
+
+    return lined
+  }
+
   function display (rules) {
     var f = function(p) {
       var n = p
       return p.toString()
     }
-    cli.table(rules, {
+
+    cli.table(lined(rules), {
       columns: [
+        {key: 'line', label: 'Rule Number'},
         {key: 'target', label: 'Destination'},
         {key: 'from_port', label: 'From Port', format: from_port => f(from_port)},
         {key: 'to_port', label: 'To Port'},
@@ -43,9 +62,27 @@ module.exports = function (heroku) {
     })
   }
 
+  function parsePorts (p) {
+    if (p == "-1") {
+      return [0,65535]
+    }
+
+    if (p != null) {
+      var ports = p.split('..')
+      if (ports.length > 1) {
+        return [ports[0] | 0, ports[1] | 0]
+      } else {
+        return [ports[0] | 0, ports[0] | 0]
+      }
+    } else {
+      return []
+    }
+  }
+
   return {
     getOutboundRules,
     putOutboundRules,
-    displayRules
+    displayRules,
+    parsePorts
   }
 }

--- a/lib/outbound-rules.js
+++ b/lib/outbound-rules.js
@@ -66,7 +66,7 @@ module.exports = function (heroku) {
     }
 
     if (p != null) {
-      var ports = p.split('..')
+      var ports = p.split('-')
       if (ports.length > 1) {
         return [ports[0] | 0, ports[1] | 0]
       } else {

--- a/lib/outbound-rules.js
+++ b/lib/outbound-rules.js
@@ -29,15 +29,13 @@ module.exports = function (heroku) {
   }
 
   function lined (rules) {
-    var count = 0
     var lined = []
     for (var i = 0, len = rules.length; i < len; i++) {
       lined.push({
-        line: i+1,
+        line: i + 1,
         target: rules[i].target,
         from_port: rules[i].from_port,
         to_port: rules[i].to_port,
-        target: rules[i].target,
         protocol: rules[i].protocol
       })
     }
@@ -46,25 +44,25 @@ module.exports = function (heroku) {
   }
 
   function display (rules) {
-    var f = function(p) {
+    var f = function (p) {
       var n = p
-      return p.toString()
+      return n.toString()
     }
 
     cli.table(lined(rules), {
       columns: [
         {key: 'line', label: 'Rule Number'},
         {key: 'target', label: 'Destination'},
-        {key: 'from_port', label: 'From Port', format: from_port => f(from_port)},
-        {key: 'to_port', label: 'To Port'},
+        {key: 'from_port', label: 'From Port', format: fromPort => f(fromPort)},
+        {key: 'to_port', label: 'To Port', format: toPort => f(toPort)},
         {key: 'protocol', label: 'Protocol'}
       ]
     })
   }
 
   function parsePorts (p) {
-    if (p == "-1") {
-      return [0,65535]
+    if (p === '-1' || p === 'any') {
+      return [0, 65535]
     }
 
     if (p != null) {

--- a/lib/outbound-rules.js
+++ b/lib/outbound-rules.js
@@ -60,21 +60,32 @@ module.exports = function (heroku) {
     })
   }
 
-  function parsePorts (p) {
+  function parsePorts (proto, p) {
     if (p === '-1' || p === 'any') {
-      return [0, 65535]
+      if (proto === 'icmp') {
+        return [0, 255]
+      } else {
+        return [0, 65535]
+      }
     }
 
+    var actual = []
     if (p != null) {
       var ports = p.split('-')
-      if (ports.length > 1) {
-        return [ports[0] | 0, ports[1] | 0]
+      if (ports.length === 2) {
+        actual = [ports[0] | 0, ports[1] | 0]
+      } else if (ports.length === 1) {
+        actual = [ports[0] | 0, ports[0] | 0]
       } else {
-        return [ports[0] | 0, ports[0] | 0]
+        throw new Error('Specified --port range seems incorrect.')
       }
-    } else {
-      return []
     }
+
+    if (actual.length !== 2) {
+      throw new Error('Specified --port range seems incorrect.')
+    }
+
+    return actual
   }
 
   return {

--- a/test/commands/outbound-rules/add.js
+++ b/test/commands/outbound-rules/add.js
@@ -1,0 +1,31 @@
+'use strict'
+/* globals describe beforeEach it */
+
+let nock = require('nock')
+let cmd = require('../../../commands/outbound-rules/add')
+let cli = require('heroku-cli-util')
+
+describe('outbound-rules:add', function () {
+  beforeEach(() => cli.mockConsole())
+
+  it('adds a rule entry to the outbound rules', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+      .put('/spaces/my-space/outbound-ruleset', {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'},
+          {target: '128.0.1.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+      .reply(200, {rules: []})
+    return cmd.run({flags: {space: 'my-space', dest: '128.0.1.1/20', port: '80', protocol: 'tcp'}})
+      .then(() => api.done())
+  })
+})

--- a/test/commands/outbound-rules/add.js
+++ b/test/commands/outbound-rules/add.js
@@ -2,6 +2,7 @@
 /* globals describe beforeEach it */
 
 let nock = require('nock')
+let chai = require('chai')
 let cmd = require('../../../commands/outbound-rules/add')
 let cli = require('heroku-cli-util')
 
@@ -50,6 +51,39 @@ describe('outbound-rules:add', function () {
       .then(() => api.done())
   })
 
+  it('handles strange port range case of 80-', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+      .put('/spaces/my-space/outbound-ruleset', {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'},
+          {target: '128.0.1.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+      .reply(200, {rules: []})
+    return cmd.run({flags: {space: 'my-space', dest: '128.0.1.1/20', port: '80-', protocol: 'tcp'}})
+      .then(() => api.done())
+  })
+
+  it('handles strange port range case of 80-100-200', function () {
+    nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+    return chai.assert.isRejected(cmd.run({flags: {space: 'my-space', dest: '128.0.1.1/20', port: '80-100-200', protocol: 'tcp'}}), /^Error: Specified --port range seems incorrect.$/)
+  })
+
   it('supports -1 as port', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/outbound-ruleset')
@@ -89,6 +123,27 @@ describe('outbound-rules:add', function () {
       })
       .reply(200, {rules: []})
     return cmd.run({flags: {space: 'my-space', dest: '128.0.1.1/20', port: 'any', protocol: 'tcp'}})
+      .then(() => api.done())
+  })
+
+  it('correct supports any as port for ICMP', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+      .put('/spaces/my-space/outbound-ruleset', {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'},
+          {target: '128.0.1.1/20', from_port: 0, to_port: 255, protocol: 'icmp'}
+        ]
+      })
+      .reply(200, {rules: []})
+    return cmd.run({flags: {space: 'my-space', dest: '128.0.1.1/20', port: 'any', protocol: 'icmp'}})
       .then(() => api.done())
   })
 })

--- a/test/commands/outbound-rules/add.js
+++ b/test/commands/outbound-rules/add.js
@@ -28,4 +28,67 @@ describe('outbound-rules:add', function () {
     return cmd.run({flags: {space: 'my-space', dest: '128.0.1.1/20', port: '80', protocol: 'tcp'}})
       .then(() => api.done())
   })
+
+  it('support ranges', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+      .put('/spaces/my-space/outbound-ruleset', {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'},
+          {target: '128.0.1.1/20', from_port: 80, to_port: 100, protocol: 'tcp'}
+        ]
+      })
+      .reply(200, {rules: []})
+    return cmd.run({flags: {space: 'my-space', dest: '128.0.1.1/20', port: '80-100', protocol: 'tcp'}})
+      .then(() => api.done())
+  })
+
+  it('supports -1 as port', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+      .put('/spaces/my-space/outbound-ruleset', {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'},
+          {target: '128.0.1.1/20', from_port: 0, to_port: 65535, protocol: 'tcp'}
+        ]
+      })
+      .reply(200, {rules: []})
+    return cmd.run({flags: {space: 'my-space', dest: '128.0.1.1/20', port: '-1', protocol: 'tcp'}})
+      .then(() => api.done())
+  })
+
+  it('supports any as port', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+      .put('/spaces/my-space/outbound-ruleset', {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'},
+          {target: '128.0.1.1/20', from_port: 0, to_port: 65535, protocol: 'tcp'}
+        ]
+      })
+      .reply(200, {rules: []})
+    return cmd.run({flags: {space: 'my-space', dest: '128.0.1.1/20', port: 'any', protocol: 'tcp'}})
+      .then(() => api.done())
+  })
 })

--- a/test/commands/outbound-rules/index.js
+++ b/test/commands/outbound-rules/index.js
@@ -1,0 +1,71 @@
+'use strict'
+/* globals describe beforeEach it */
+
+let nock = require('nock')
+let cmd = require('../../../commands/outbound-rules')
+let expect = require('chai').expect
+let cli = require('heroku-cli-util')
+
+let now = new Date()
+
+describe('outbound-rules', function () {
+  beforeEach(() => cli.mockConsole())
+
+  it('shows the outbound rules', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, {
+        version: '1',
+        created_at: now,
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+    return cmd.run({flags: {space: 'my-space'}})
+      .then(() => expect(cli.stdout).to.equal(
+        `=== Outbound Rules
+Rule Number  Destination   From Port  To Port  Protocol
+───────────  ────────────  ─────────  ───────  ────────
+1            128.0.0.1/20  80         80       tcp
+`))
+      .then(() => api.done())
+  })
+
+  it('shows the empty ruleset message when empty', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, {
+        version: '1',
+        default_action: 'allow',
+        created_at: now,
+        created_by: 'dickeyxxx',
+        rules: []
+      })
+    return cmd.run({flags: {space: 'my-space'}})
+      .then(() => expect(cli.stdout).to.equal(
+        `=== my-space has no Outbound Rules. Your Dynos cannot communicate with hosts outside of my-space.
+`))
+      .then(() => api.done())
+  })
+
+  it('shows the outbound rules via JSON when --json is passed', function () {
+    let ruleSet = {
+      version: '1',
+      default_action: 'allow',
+      created_at: now.toISOString(),
+      created_by: 'dickeyxxx',
+      rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+      ]
+    }
+
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, ruleSet)
+
+    return cmd.run({flags: {space: 'my-space', json: true}})
+      .then(() => expect(JSON.parse(cli.stdout)).to.eql(ruleSet))
+      .then(() => api.done())
+  })
+})

--- a/test/commands/outbound-rules/remmove.js
+++ b/test/commands/outbound-rules/remmove.js
@@ -26,7 +26,7 @@ describe('outbound-rules:remove', function () {
         ]
       })
       .reply(200, {rules: []})
-    return cmd.run({args: {rulenumber: 2}, flags: {space: 'my-space', confirm: 'my-space'}})
+    return cmd.run({args: {ruleNumber: 2}, flags: {space: 'my-space', confirm: 'my-space'}})
       .then(() => api.done())
   })
 })

--- a/test/commands/outbound-rules/remmove.js
+++ b/test/commands/outbound-rules/remmove.js
@@ -1,0 +1,32 @@
+'use strict'
+/* globals describe it beforeEach */
+
+let nock = require('nock')
+let cmd = require('../../../commands/outbound-rules/remove')
+let cli = require('heroku-cli-util')
+
+describe('outbound-rules:remove', function () {
+  beforeEach(() => cli.mockConsole())
+
+  it('removes a rule entry from the outbound rules', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/outbound-ruleset')
+      .reply(200, {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'},
+          {target: '128.0.0.1/20', from_port: 443, to_port: 443, protocol: 'udp'}
+        ]
+      }
+    )
+      .put('/spaces/my-space/outbound-ruleset', {
+        created_by: 'dickeyxxx',
+        rules: [
+          {target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp'}
+        ]
+      })
+      .reply(200, {rules: []})
+    return cmd.run({args: {rulenumber: 2}, flags: {space: 'my-space', confirm: 'my-space'}})
+      .then(() => api.done())
+  })
+})


### PR DESCRIPTION
cc @jsullivan 

This adds support to the heroku-spaces plugin to handle management of the Outbound Rules feature.

This supports the following commands:

`heroku outbound-rules --space <<space>>`
`heroku outbound-rules:add --space <<space>> --dest 0.0.0.0/0 --protocol tcp --port any`
`heroku outbound-rules:remove --space <<space>>  <<rule number>>`

# Adding Rule:

You can pass a range of port options

```shell
% heroku outbound-rules:add --space example-space --dest 0.0.0.0/0 --protocol tcp --port 80
Parsing heroku-spaces... done
Added rule to the Outbound Rules of example-space
 ▸    It may take a few moments for the changes to take effect.
```

With a range
```shell
% heroku outbound-rules:add --space example-space --dest 0.0.0.0/0 --protocol tcp --port 80-100
Parsing heroku-spaces... done
Added rule to the Outbound Rules of example-space
 ▸    It may take a few moments for the changes to take effect.
```

Any Port
```shell
% heroku outbound-rules:add --space example-space --dest 0.0.0.0/0 --protocol tcp --port any
Parsing heroku-spaces... done
Added rule to the Outbound Rules of example-space
 ▸    It may take a few moments for the changes to take effect.
```


# Listing Rules:

```shell
% heroku outbound-rules --space example-space
=== Outbound Rules
Rule Number  Destination  From Port  To Port  Protocol
───────────  ───────────  ─────────  ───────  ────────
1            0.0.0.0/0    0                   any
2            0.0.0.0/0    0                   tcp
```

# Removing Rules
```shell
% heroku outbound-rules:remove --space example-space 2
 ▸    Destructive Action
 ▸    This will remove:
 ▸    Destination: 0.0.0.0/0, From Port: 0, To Port: 0, Protocol any
 ▸    from the Outbound Rules on example-space
 ▸
 ▸    To proceed, type example-space or re-run this command with --confirm example-space

> example-space
Removed Rule 2 from Outbound Rules on example-space
 ▸    It may take a few moments for the changes to take effect.
```
